### PR TITLE
forAllImagesInElement: Add reject when loading fails

### DIFF
--- a/src/functions/forAllImagesInElement.ts
+++ b/src/functions/forAllImagesInElement.ts
@@ -4,9 +4,12 @@ export async function forAllImagesInElement(
     await Promise.all(
         Array.from(element.querySelectorAll('img')).map(
             (imgElement) =>
-                new Promise((resolve) => {
+                new Promise((resolve, reject) => {
                     imgElement.addEventListener('load', () => {
                         resolve();
+                    });
+                    imgElement.addEventListener('error', (event) => {
+                        reject(event.target);
                     });
                 }),
         ),


### PR DESCRIPTION
`forAllImagesInElement` waiter can be never resoved when any image fails.

This PR add throwing error when any image failed.