### PR TITLE
forAllImagesInElement: Images check load state

### DIFF
--- a/docs/globals.html
+++ b/docs/globals.html
@@ -983,7 +983,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f5439d/src/functions/forAllImagesInElement.ts#L1">functions/forAllImagesInElement.ts:1</a></li>
+								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f9d0c6/src/functions/forAllImagesInElement.ts#L1">functions/forAllImagesInElement.ts:1</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1006,7 +1006,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f5439d/src/functions/forAnimationFrame.ts#L1">functions/forAnimationFrame.ts:1</a></li>
+								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f9d0c6/src/functions/forAnimationFrame.ts#L1">functions/forAnimationFrame.ts:1</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -1023,7 +1023,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f5439d/src/functions/forDocumentLoad.ts#L1">functions/forDocumentLoad.ts:1</a></li>
+								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f9d0c6/src/functions/forDocumentLoad.ts#L1">functions/forDocumentLoad.ts:1</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -1040,7 +1040,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f5439d/src/functions/forImmediate.ts#L1">functions/forImmediate.ts:1</a></li>
+								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f9d0c6/src/functions/forImmediate.ts#L1">functions/forImmediate.ts:1</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -1057,7 +1057,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f5439d/src/functions/forTime.ts#L1">functions/forTime.ts:1</a></li>
+								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f9d0c6/src/functions/forTime.ts#L1">functions/forTime.ts:1</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1080,7 +1080,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f5439d/src/functions/forValueDefined.ts#L3">functions/forValueDefined.ts:3</a></li>
+								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f9d0c6/src/functions/forValueDefined.ts#L3">functions/forValueDefined.ts:3</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/index.html
+++ b/docs/index.html
@@ -984,7 +984,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f5439d/src/functions/forAllImagesInElement.ts#L1">functions/forAllImagesInElement.ts:1</a></li>
+								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f9d0c6/src/functions/forAllImagesInElement.ts#L1">functions/forAllImagesInElement.ts:1</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1007,7 +1007,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f5439d/src/functions/forAnimationFrame.ts#L1">functions/forAnimationFrame.ts:1</a></li>
+								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f9d0c6/src/functions/forAnimationFrame.ts#L1">functions/forAnimationFrame.ts:1</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -1024,7 +1024,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f5439d/src/functions/forDocumentLoad.ts#L1">functions/forDocumentLoad.ts:1</a></li>
+								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f9d0c6/src/functions/forDocumentLoad.ts#L1">functions/forDocumentLoad.ts:1</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -1041,7 +1041,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f5439d/src/functions/forImmediate.ts#L1">functions/forImmediate.ts:1</a></li>
+								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f9d0c6/src/functions/forImmediate.ts#L1">functions/forImmediate.ts:1</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -1058,7 +1058,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f5439d/src/functions/forTime.ts#L1">functions/forTime.ts:1</a></li>
+								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f9d0c6/src/functions/forTime.ts#L1">functions/forTime.ts:1</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1081,7 +1081,7 @@ img { max-width: 100%; }
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f5439d/src/functions/forValueDefined.ts#L3">functions/forValueDefined.ts:3</a></li>
+								<li>Defined in <a href="https://github.com/hejny/waitasecond/blob/2f9d0c6/src/functions/forValueDefined.ts#L3">functions/forValueDefined.ts:3</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/src/functions/forAllImagesInElement.ts
+++ b/src/functions/forAllImagesInElement.ts
@@ -3,15 +3,26 @@ export async function forAllImagesInElement(
 ): Promise<void> {
     await Promise.all(
         Array.from(element.querySelectorAll('img')).map(
-            (imgElement) =>
-                new Promise((resolve, reject) => {
+            (imgElement) => {
+                return new Promise((resolve, reject) => {
+                    if(imgElement.complete) {
+                        if(imgElement.naturalHeight === 0) {
+                            reject(imgElement);
+                        } else {
+                            resolve();
+                        }
+
+                        return;
+                    };
+
                     imgElement.addEventListener('load', () => {
                         resolve();
                     });
-                    imgElement.addEventListener('error', (event) => {
-                        reject(event.target);
+                    imgElement.addEventListener('error', () => {
+                        reject(imgElement);
                     });
-                }),
+                })
+            }
         ),
     );
     return;

--- a/src/functions/forAllImagesInElement.ts
+++ b/src/functions/forAllImagesInElement.ts
@@ -4,9 +4,12 @@ export async function forAllImagesInElement(
     await Promise.all(
         Array.from(element.querySelectorAll('img')).map(
             (imgElement) =>
-                new Promise((resolve) => {
+                new Promise((resolve, reject) => {
                     imgElement.addEventListener('load', () => {
                         resolve();
+                    });
+                    imgElement.addEventListener('error', (event) => {
+                        reject(event.target);
                     });
                 }),
         ),


### PR DESCRIPTION
`forAllImagesInElement` waiter can be never resoved when any image is loaded before waiter initialized.

This is not a just marginally case, because browser can boost loading by cache, and event is binded to image element asynchronously (inside `new Promise()` callback). 

This PR is checking if loading state of image isn't already completed. If is, it resolve/reject promise immediately.

Note: This PS is depends on PS #2!